### PR TITLE
Attempt to fix concurrency tests

### DIFF
--- a/src/pbservice/client.go
+++ b/src/pbservice/client.go
@@ -77,6 +77,8 @@ func call(srv string, rpcname string,
 //
 func (ck *Clerk) Get(key string) string {
 
+	// fmt.Println("Clerk GET\n")
+
 	// Your code here.
 
 	var primary string
@@ -106,6 +108,8 @@ func (ck *Clerk) Get(key string) string {
 //
 func (ck *Clerk) PutAppend(key string, value string, op string) {
 
+	// THESE ARE INTERLEAVED!
+
 	// RPC Get() on VS to find current view
 	// Now I know the primary
 	// RPC PutAppend() on the primary
@@ -117,7 +121,9 @@ func (ck *Clerk) PutAppend(key string, value string, op string) {
 	put_args.Hash = nrand()
 
 	for {
-		fmt.Printf("Put")
+		// MERMAID
+		// fmt.Printf("Client PutAppend\n")
+
 		var primary string
 
 		if view, ok := ck.vs.Get(); !ok {

--- a/src/pbservice/server.go
+++ b/src/pbservice/server.go
@@ -42,7 +42,7 @@ func (pb *PBServer) TransferDB(args *TransferDBArgs, reply *TransferDBReply) err
 
 func (pb *PBServer) Get(args *GetArgs, reply *GetReply) error {
 
-	// Your code here.
+	fmt.Println("Server GET\n")
 
 	key := args.Key
 
@@ -63,7 +63,10 @@ func (pb *PBServer) PutAppend(args *PutAppendArgs, reply *PutAppendReply) error 
 
 	// Your code here.
 
-	// Only ever atomically add things :P
+	// Only ever atomically add things
+	// is this too high?
+	// fmt.Println("Server PutAppend")
+	fmt.Println("PutAppend. Locking..")
 	pb.mu.Lock()
 	defer pb.mu.Unlock()
 

--- a/src/pbservice/test_test.go
+++ b/src/pbservice/test_test.go
@@ -2,15 +2,17 @@ package pbservice
 
 import "viewservice"
 import "fmt"
-import "io"
-import "net"
+
+// import "io"
+// import "net"
 import "testing"
 import "time"
 import "log"
 import "runtime"
 import "math/rand"
 import "os"
-import "sync"
+
+// import "sync"
 import "strconv"
 import "strings"
 import "sync/atomic"
@@ -69,7 +71,7 @@ func TestBasicFail(t *testing.T) {
 	ck.Append("ak", "yy")
 	check(ck, "ak", "xxyy")
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	// add a backup
 
@@ -97,7 +99,7 @@ func TestBasicFail(t *testing.T) {
 	ck.Put("4", "44")
 	check(ck, "4", "44")
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	fmt.Printf("Test: Count RPCs to viewserver ...\n")
 
@@ -120,7 +122,7 @@ func TestBasicFail(t *testing.T) {
 		t.Fatal("too many viewserver RPCs")
 	}
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	// kill the primary
 
@@ -143,7 +145,7 @@ func TestBasicFail(t *testing.T) {
 	check(ck, "3", "33")
 	check(ck, "4", "44")
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	// kill solo server, start new server, check that
 	// it does not start serving as primary
@@ -165,7 +167,7 @@ func TestBasicFail(t *testing.T) {
 	case <-time.After(2 * time.Second):
 	}
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	s1.kill()
 	s2.kill()
@@ -218,7 +220,7 @@ func TestAtMostOnce(t *testing.T) {
 		t.Fatalf("ck.Get() returned %v but expected %v\n", v, val)
 	}
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	for i := 0; i < nservers; i++ {
 		sa[i].kill()
@@ -286,7 +288,8 @@ func TestFailPut(t *testing.T) {
 	}
 
 	check(ck, "a", "aaa")
-	fmt.Printf("  ... Passed\n")
+
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	// kill primary, then immediate Put
 	fmt.Printf("Test: Put() immediately after primary failure ...\n")
@@ -306,7 +309,8 @@ func TestFailPut(t *testing.T) {
 	check(ck, "a", "aaa")
 	check(ck, "b", "bbb")
 	check(ck, "c", "cc")
-	fmt.Printf("  ... Passed\n")
+
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	s1.kill()
 	s2.kill()
@@ -315,9 +319,14 @@ func TestFailPut(t *testing.T) {
 	vs.Kill()
 }
 
+// MERMAID: The above tests are passing CONSISTENTLY
+
 // do a bunch of concurrent Put()s on the same key,
 // then check that primary and backup have identical values.
 // i.e. that they processed the Put()s in the same order.
+
+// @eburdon - I'm pretty sure THIS is the test sporadically failing!
+// The following two concurrency tests!
 func TestConcurrentSame(t *testing.T) {
 	runtime.GOMAXPROCS(4)
 
@@ -349,6 +358,7 @@ func TestConcurrentSame(t *testing.T) {
 	done := int32(0)
 
 	view1, _ := vck.Get()
+
 	const nclients = 3
 	const nkeys = 2
 	for xi := 0; xi < nclients; xi++ {
@@ -369,6 +379,7 @@ func TestConcurrentSame(t *testing.T) {
 
 	// read from primary
 	ck := MakeClerk(vshost, "")
+
 	var vals [nkeys]string
 	for i := 0; i < nkeys; i++ {
 		vals[i] = ck.Get(strconv.Itoa(i))
@@ -384,6 +395,7 @@ func TestConcurrentSame(t *testing.T) {
 			break
 		}
 	}
+
 	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
 		view, _ := vck.Get()
 		if view.Primary == view1.Backup {
@@ -391,9 +403,10 @@ func TestConcurrentSame(t *testing.T) {
 		}
 		time.Sleep(viewservice.PingInterval)
 	}
+
 	view2, _ := vck.Get()
 	if view2.Primary != view1.Backup {
-		t.Fatal("wrong Primary")
+		t.Fatal("wrong Primary") // @eburdon sometimes this error is hit instead
 	}
 
 	// read from old backup
@@ -404,7 +417,7 @@ func TestConcurrentSame(t *testing.T) {
 		}
 	}
 
-	fmt.Printf("  ... Passed\n")
+	fmt.Printf("  ... Passed\n\n\n\n")
 
 	for i := 0; i < nservers; i++ {
 		sa[i].kill()
@@ -440,704 +453,723 @@ func checkAppends(t *testing.T, v string, counts []int) {
 
 // do a bunch of concurrent Append()s on the same key,
 // then check that primary and backup have identical values.
-// i.e. that they processed the Append()s in the same order.
-func TestConcurrentSameAppend(t *testing.T) {
-	runtime.GOMAXPROCS(4)
+// // i.e. that they processed the Append()s in the same order.
+// func TestConcurrentSameAppend(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
 
-	tag := "csa"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
+// 	tag := "csa"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
 
-	fmt.Printf("Test: Concurrent Append()s to the same key ...\n")
+// 	// @eburdon -- THIS GETS HUNG UP WHEN SOMETHING DIES (cs-2)
+// 	fmt.Printf("Test: Concurrent Append()s to the same key ...\n")
 
-	const nservers = 2
-	var sa [nservers]*PBServer
-	for i := 0; i < nservers; i++ {
-		sa[i] = StartServer(vshost, port(tag, i+1))
-	}
+// 	const nservers = 2
+// 	var sa [nservers]*PBServer
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i] = StartServer(vshost, port(tag, i+1))
+// 	}
 
-	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
-		view, _ := vck.Get()
-		if view.Primary != "" && view.Backup != "" {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
+// 	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
+// 		view, _ := vck.Get()
+// 		if view.Primary != "" && view.Backup != "" {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
 
-	// give p+b time to ack, initialize
-	time.Sleep(viewservice.PingInterval * viewservice.DeadPings)
+// 	// give p+b time to ack, initialize
+// 	time.Sleep(viewservice.PingInterval * viewservice.DeadPings)
 
-	view1, _ := vck.Get()
+// 	view1, _ := vck.Get()
 
-	// code for i'th concurrent client thread.
-	ff := func(i int, ch chan int) {
-		ret := -1
-		defer func() { ch <- ret }()
-		ck := MakeClerk(vshost, "")
-		n := 0
-		for n < 50 {
-			v := "x " + strconv.Itoa(i) + " " + strconv.Itoa(n) + " y"
-			ck.Append("k", v)
-			n += 1
-		}
-		ret = n
-	}
+// 	// code for i'th concurrent client thread.
+// 	ff := func(i int, ch chan int) {
+// 		ret := -1
+// 		defer func() { ch <- ret }()
+// 		ck := MakeClerk(vshost, "")
+// 		n := 0
+// 		for n < 50 {
+// 			v := "x " + strconv.Itoa(i) + " " + strconv.Itoa(n) + " y"
+// 			ck.Append("k", v)
+// 			n += 1
+// 		}
+// 		ret = n
+// 	}
 
-	// start the concurrent clients
-	const nclients = 3
-	chans := []chan int{}
-	for i := 0; i < nclients; i++ {
-		chans = append(chans, make(chan int))
-		go ff(i, chans[i])
-	}
+// 	// start the concurrent clients
+// 	const nclients = 3
+// 	chans := []chan int{}
+// 	for i := 0; i < nclients; i++ {
+// 		chans = append(chans, make(chan int))
+// 		go ff(i, chans[i])
+// 	}
 
-	// wait for the clients, accumulate Append counts.
-	counts := []int{}
-	for i := 0; i < nclients; i++ {
-		n := <-chans[i]
-		if n < 0 {
-			t.Fatalf("child failed")
-		}
-		counts = append(counts, n)
-	}
+// 	// wait for the clients, accumulate Append counts.
+// 	counts := []int{}
+// 	for i := 0; i < nclients; i++ {
+// 		n := <-chans[i]
+// 		if n < 0 {
+// 			t.Fatalf("child failed")
+// 		}
+// 		counts = append(counts, n)
+// 	}
 
-	ck := MakeClerk(vshost, "")
+// 	ck := MakeClerk(vshost, "")
 
-	// check that primary's copy of the value has all
-	// the Append()s.
-	primaryv := ck.Get("k")
-	checkAppends(t, primaryv, counts)
+// 	// check that primary's copy of the value has all
+// 	// the Append()s.
+// 	primaryv := ck.Get("k")
 
-	// kill the primary so we can check the backup
-	for i := 0; i < nservers; i++ {
-		if view1.Primary == sa[i].me {
-			sa[i].kill()
-			break
-		}
-	}
-	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
-		view, _ := vck.Get()
-		if view.Primary == view1.Backup {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-	view2, _ := vck.Get()
-	if view2.Primary != view1.Backup {
-		t.Fatal("wrong Primary")
-	}
+// 	checkAppends(t, primaryv, counts)
 
-	// check that backup's copy of the value has all
-	// the Append()s.
-	backupv := ck.Get("k")
-	checkAppends(t, backupv, counts)
+// 	// kill the primary so we can check the backup
+// 	for i := 0; i < nservers; i++ {
+// 		if view1.Primary == sa[i].me {
+// 			sa[i].kill()
+// 			break
+// 		}
+// 	}
 
-	if backupv != primaryv {
-		t.Fatal("primary and backup had different values")
-	}
+// 	fmt.Printf("Primary dead.\n")
 
-	fmt.Printf("  ... Passed\n")
+// 	// @eburdon: HERE IT FAILS (on vck.get)
 
-	for i := 0; i < nservers; i++ {
-		sa[i].kill()
-	}
-	time.Sleep(time.Second)
-	vs.Kill()
-	time.Sleep(time.Second)
-}
+// 	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
+// 		fmt.Printf("Getting view [concurrent appends]\n")
+// 		view, _ := vck.Get()
+// 		fmt.Printf("Have view\n")
+// 		if view.Primary == view1.Backup {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
 
-func TestConcurrentSameUnreliable(t *testing.T) {
-	runtime.GOMAXPROCS(4)
+// 	fmt.Printf("After for loop \n");
 
-	tag := "csu"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
+// 	view2, _ := vck.Get()
 
-	fmt.Printf("Test: Concurrent Put()s to the same key; unreliable ...\n")
+// 	if view2.Primary != view1.Backup {
+// 		t.Fatal("wrong Primary")
+// 	}
 
-	const nservers = 2
-	var sa [nservers]*PBServer
-	for i := 0; i < nservers; i++ {
-		sa[i] = StartServer(vshost, port(tag, i+1))
-		sa[i].setunreliable(true)
-	}
+// 	// check that backup's copy of the value has all
+// 	// the Append()s.
+// 	backupv := ck.Get("k")
 
-	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
-		view, _ := vck.Get()
-		if view.Primary != "" && view.Backup != "" {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
+// 	checkAppends(t, backupv, counts)
 
-	// give p+b time to ack, initialize
-	time.Sleep(viewservice.PingInterval * viewservice.DeadPings)
+// 	if backupv != primaryv {
+// 		t.Fatal("primary and backup had different values")
+// 	}
 
-	{
-		ck := MakeClerk(vshost, "")
-		ck.Put("0", "x")
-		ck.Put("1", "x")
-	}
+// 	fmt.Printf("  ... Passed\n\n\n\n")
 
-	done := int32(0)
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i].kill()
+// 	}
 
-	view1, _ := vck.Get()
-	const nclients = 3
-	const nkeys = 2
-	cha := []chan bool{}
-	for xi := 0; xi < nclients; xi++ {
-		cha = append(cha, make(chan bool))
-		go func(i int, ch chan bool) {
-			ok := false
-			defer func() { ch <- ok }()
-			ck := MakeClerk(vshost, "")
-			rr := rand.New(rand.NewSource(int64(os.Getpid() + i)))
-			for atomic.LoadInt32(&done) == 0 {
-				k := strconv.Itoa(rr.Int() % nkeys)
-				v := strconv.Itoa(rr.Int())
-				ck.Put(k, v)
-			}
-			ok = true
-		}(xi, cha[xi])
-	}
+// 	time.Sleep(time.Second)
+// 	vs.Kill()
+// 	time.Sleep(time.Second)
+// }
 
-	time.Sleep(5 * time.Second)
-	atomic.StoreInt32(&done, 1)
+// func TestConcurrentSameUnreliable(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
 
-	for i := 0; i < len(cha); i++ {
-		ok := <-cha[i]
-		if ok == false {
-			t.Fatalf("child failed")
-		}
-	}
+// 	tag := "csu"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
 
-	// read from primary
-	ck := MakeClerk(vshost, "")
-	var vals [nkeys]string
-	for i := 0; i < nkeys; i++ {
-		vals[i] = ck.Get(strconv.Itoa(i))
-		if vals[i] == "" {
-			t.Fatalf("Get(%v) failed from primary", i)
-		}
-	}
+// 	fmt.Printf("Test: Concurrent Put()s to the same key; unreliable ...\n")
 
-	// kill the primary
-	for i := 0; i < nservers; i++ {
-		if view1.Primary == sa[i].me {
-			sa[i].kill()
-			break
-		}
-	}
-	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
-		view, _ := vck.Get()
-		if view.Primary == view1.Backup {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-	view2, _ := vck.Get()
-	if view2.Primary != view1.Backup {
-		t.Fatal("wrong Primary")
-	}
+// 	const nservers = 2
+// 	var sa [nservers]*PBServer
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i] = StartServer(vshost, port(tag, i+1))
+// 		sa[i].setunreliable(true)
+// 	}
 
-	// read from old backup
-	for i := 0; i < nkeys; i++ {
-		z := ck.Get(strconv.Itoa(i))
-		if z != vals[i] {
-			t.Fatalf("Get(%v) from backup; wanted %v, got %v", i, vals[i], z)
-		}
-	}
+// 	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
+// 		view, _ := vck.Get()
+// 		if view.Primary != "" && view.Backup != "" {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
 
-	fmt.Printf("  ... Passed\n")
+// 	// give p+b time to ack, initialize
+// 	time.Sleep(viewservice.PingInterval * viewservice.DeadPings)
 
-	for i := 0; i < nservers; i++ {
-		sa[i].kill()
-	}
-	time.Sleep(time.Second)
-	vs.Kill()
-	time.Sleep(time.Second)
-}
+// 	{
+// 		ck := MakeClerk(vshost, "")
+// 		ck.Put("0", "x")
+// 		ck.Put("1", "x")
+// 	}
+
+// 	done := int32(0)
+
+// 	view1, _ := vck.Get()
+// 	const nclients = 3
+// 	const nkeys = 2
+// 	cha := []chan bool{}
+// 	for xi := 0; xi < nclients; xi++ {
+// 		cha = append(cha, make(chan bool))
+// 		go func(i int, ch chan bool) {
+// 			ok := false
+// 			defer func() { ch <- ok }()
+// 			ck := MakeClerk(vshost, "")
+// 			rr := rand.New(rand.NewSource(int64(os.Getpid() + i)))
+// 			for atomic.LoadInt32(&done) == 0 {
+// 				k := strconv.Itoa(rr.Int() % nkeys)
+// 				v := strconv.Itoa(rr.Int())
+// 				ck.Put(k, v)
+// 			}
+// 			ok = true
+// 		}(xi, cha[xi])
+// 	}
+
+// 	time.Sleep(5 * time.Second)
+// 	atomic.StoreInt32(&done, 1)
+
+// 	for i := 0; i < len(cha); i++ {
+// 		ok := <-cha[i]
+// 		if ok == false {
+// 			t.Fatalf("child failed")
+// 		}
+// 	}
+
+// 	// read from primary
+// 	ck := MakeClerk(vshost, "")
+// 	var vals [nkeys]string
+// 	for i := 0; i < nkeys; i++ {
+// 		vals[i] = ck.Get(strconv.Itoa(i))
+// 		if vals[i] == "" {
+// 			t.Fatalf("Get(%v) failed from primary", i)
+// 		}
+// 	}
+
+// 	// kill the primary
+// 	for i := 0; i < nservers; i++ {
+// 		if view1.Primary == sa[i].me {
+// 			sa[i].kill()
+// 			break
+// 		}
+// 	}
+// 	for iters := 0; iters < viewservice.DeadPings*2; iters++ {
+// 		view, _ := vck.Get()
+// 		if view.Primary == view1.Backup {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+// 	view2, _ := vck.Get()
+// 	if view2.Primary != view1.Backup {
+// 		t.Fatal("wrong Primary")
+// 	}
+
+// 	// read from old backup
+// 	for i := 0; i < nkeys; i++ {
+// 		z := ck.Get(strconv.Itoa(i))
+// 		if z != vals[i] {
+// 			t.Fatalf("Get(%v) from backup; wanted %v, got %v", i, vals[i], z)
+// 		}
+// 	}
+
+// 	fmt.Printf("  ... Passed\n")
+
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i].kill()
+// 	}
+// 	time.Sleep(time.Second)
+// 	vs.Kill()
+// 	time.Sleep(time.Second)
+// }
 
 // constant put/get while crashing and restarting servers
-func TestRepeatedCrash(t *testing.T) {
-	runtime.GOMAXPROCS(4)
-
-	tag := "rc"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
-
-	fmt.Printf("Test: Repeated failures/restarts ...\n")
-
-	const nservers = 3
-	var sa [nservers]*PBServer
-	samu := sync.Mutex{}
-	for i := 0; i < nservers; i++ {
-		sa[i] = StartServer(vshost, port(tag, i+1))
-	}
-
-	for i := 0; i < viewservice.DeadPings; i++ {
-		v, _ := vck.Get()
-		if v.Primary != "" && v.Backup != "" {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-
-	// wait a bit for primary to initialize backup
-	time.Sleep(viewservice.DeadPings * viewservice.PingInterval)
-
-	done := int32(0)
-
-	go func() {
-		// kill and restart servers
-		rr := rand.New(rand.NewSource(int64(os.Getpid())))
-		for atomic.LoadInt32(&done) == 0 {
-			i := rr.Int() % nservers
-			// fmt.Printf("%v killing %v\n", ts(), 5001+i)
-			sa[i].kill()
-
-			// wait long enough for new view to form, backup to be initialized
-			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
-
-			sss := StartServer(vshost, port(tag, i+1))
-			samu.Lock()
-			sa[i] = sss
-			samu.Unlock()
-
-			// wait long enough for new view to form, backup to be initialized
-			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
-		}
-	}()
-
-	const nth = 2
-	var cha [nth]chan bool
-	for xi := 0; xi < nth; xi++ {
-		cha[xi] = make(chan bool)
-		go func(i int) {
-			ok := false
-			defer func() { cha[i] <- ok }()
-			ck := MakeClerk(vshost, "")
-			data := map[string]string{}
-			rr := rand.New(rand.NewSource(int64(os.Getpid() + i)))
-			for atomic.LoadInt32(&done) == 0 {
-				k := strconv.Itoa((i * 1000000) + (rr.Int() % 10))
-				wanted, ok := data[k]
-				if ok {
-					v := ck.Get(k)
-					if v != wanted {
-						t.Fatalf("key=%v wanted=%v got=%v", k, wanted, v)
-					}
-				}
-				nv := strconv.Itoa(rr.Int())
-				ck.Put(k, nv)
-				data[k] = nv
-				// if no sleep here, then server tick() threads do not get
-				// enough time to Ping the viewserver.
-				time.Sleep(10 * time.Millisecond)
-			}
-			ok = true
-		}(xi)
-	}
-
-	time.Sleep(20 * time.Second)
-	atomic.StoreInt32(&done, 1)
-
-	fmt.Printf("  ... Put/Gets done ... \n")
-
-	for i := 0; i < nth; i++ {
-		ok := <-cha[i]
-		if ok == false {
-			t.Fatal("child failed")
-		}
-	}
-
-	ck := MakeClerk(vshost, "")
-	ck.Put("aaa", "bbb")
-	if v := ck.Get("aaa"); v != "bbb" {
-		t.Fatalf("final Put/Get failed")
-	}
-
-	fmt.Printf("  ... Passed\n")
-
-	for i := 0; i < nservers; i++ {
-		samu.Lock()
-		sa[i].kill()
-		samu.Unlock()
-	}
-	time.Sleep(time.Second)
-	vs.Kill()
-	time.Sleep(time.Second)
-}
-
-func TestRepeatedCrashUnreliable(t *testing.T) {
-	runtime.GOMAXPROCS(4)
-
-	tag := "rcu"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
-
-	fmt.Printf("Test: Repeated failures/restarts with concurrent updates to same key; unreliable ...\n")
-
-	const nservers = 3
-	var sa [nservers]*PBServer
-	samu := sync.Mutex{}
-	for i := 0; i < nservers; i++ {
-		sa[i] = StartServer(vshost, port(tag, i+1))
-		sa[i].setunreliable(true)
-	}
-
-	for i := 0; i < viewservice.DeadPings; i++ {
-		v, _ := vck.Get()
-		if v.Primary != "" && v.Backup != "" {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-
-	// wait a bit for primary to initialize backup
-	time.Sleep(viewservice.DeadPings * viewservice.PingInterval)
-
-	done := int32(0)
-
-	go func() {
-		// kill and restart servers
-		rr := rand.New(rand.NewSource(int64(os.Getpid())))
-		for atomic.LoadInt32(&done) == 0 {
-			i := rr.Int() % nservers
-			// fmt.Printf("%v killing %v\n", ts(), 5001+i)
-			sa[i].kill()
-
-			// wait long enough for new view to form, backup to be initialized
-			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
-
-			sss := StartServer(vshost, port(tag, i+1))
-			samu.Lock()
-			sa[i] = sss
-			samu.Unlock()
-
-			// wait long enough for new view to form, backup to be initialized
-			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
-		}
-	}()
-
-	// concurrent client thread.
-	ff := func(i int, ch chan int) {
-		ret := -1
-		defer func() { ch <- ret }()
-		ck := MakeClerk(vshost, "")
-		n := 0
-		for atomic.LoadInt32(&done) == 0 {
-			v := "x " + strconv.Itoa(i) + " " + strconv.Itoa(n) + " y"
-			ck.Append("0", v)
-			// if no sleep here, then server tick() threads do not get
-			// enough time to Ping the viewserver.
-			time.Sleep(10 * time.Millisecond)
-			n++
-		}
-		ret = n
-	}
-
-	const nth = 2
-	var cha [nth]chan int
-	for i := 0; i < nth; i++ {
-		cha[i] = make(chan int)
-		go ff(i, cha[i])
-	}
-
-	time.Sleep(20 * time.Second)
-	atomic.StoreInt32(&done, 1)
-
-	fmt.Printf("  ... Appends done ... \n")
-
-	counts := []int{}
-	for i := 0; i < nth; i++ {
-		n := <-cha[i]
-		if n < 0 {
-			t.Fatal("child failed")
-		}
-		counts = append(counts, n)
-	}
-
-	ck := MakeClerk(vshost, "")
-
-	checkAppends(t, ck.Get("0"), counts)
-
-	ck.Put("aaa", "bbb")
-	if v := ck.Get("aaa"); v != "bbb" {
-		t.Fatalf("final Put/Get failed")
-	}
-
-	fmt.Printf("  ... Passed\n")
-
-	for i := 0; i < nservers; i++ {
-		samu.Lock()
-		sa[i].kill()
-		samu.Unlock()
-	}
-	time.Sleep(time.Second)
-	vs.Kill()
-	time.Sleep(time.Second)
-}
-
-func proxy(t *testing.T, port string, delay *int32) {
-	portx := port + "x"
-	os.Remove(portx)
-	if os.Rename(port, portx) != nil {
-		t.Fatalf("proxy rename failed")
-	}
-	l, err := net.Listen("unix", port)
-	if err != nil {
-		t.Fatalf("proxy listen failed: %v", err)
-	}
-	go func() {
-		defer l.Close()
-		defer os.Remove(portx)
-		defer os.Remove(port)
-		for {
-			c1, err := l.Accept()
-			if err != nil {
-				t.Fatalf("proxy accept failed: %v\n", err)
-			}
-			time.Sleep(time.Duration(atomic.LoadInt32(delay)) * time.Second)
-			c2, err := net.Dial("unix", portx)
-			if err != nil {
-				t.Fatalf("proxy dial failed: %v\n", err)
-			}
-
-			go func() {
-				for {
-					buf := make([]byte, 1000)
-					n, _ := c2.Read(buf)
-					if n == 0 {
-						break
-					}
-					n1, _ := c1.Write(buf[0:n])
-					if n1 != n {
-						break
-					}
-				}
-			}()
-			for {
-				buf := make([]byte, 1000)
-				n, err := c1.Read(buf)
-				if err != nil && err != io.EOF {
-					t.Fatalf("proxy c1.Read: %v\n", err)
-				}
-				if n == 0 {
-					break
-				}
-				n1, err1 := c2.Write(buf[0:n])
-				if err1 != nil || n1 != n {
-					t.Fatalf("proxy c2.Write: %v\n", err1)
-				}
-			}
-
-			c1.Close()
-			c2.Close()
-		}
-	}()
-}
-
-func TestPartition1(t *testing.T) {
-	runtime.GOMAXPROCS(4)
-
-	tag := "part1"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
-
-	ck1 := MakeClerk(vshost, "")
-
-	fmt.Printf("Test: Old primary does not serve Gets ...\n")
-
-	vshosta := vshost + "a"
-	os.Link(vshost, vshosta)
-
-	s1 := StartServer(vshosta, port(tag, 1))
-	delay := int32(0)
-	proxy(t, port(tag, 1), &delay)
-
-	deadtime := viewservice.PingInterval * viewservice.DeadPings
-	time.Sleep(deadtime * 2)
-	if vck.Primary() != s1.me {
-		t.Fatal("primary never formed initial view")
-	}
-
-	s2 := StartServer(vshost, port(tag, 2))
-	time.Sleep(deadtime * 2)
-	v1, _ := vck.Get()
-	if v1.Primary != s1.me || v1.Backup != s2.me {
-		t.Fatal("backup did not join view")
-	}
-
-	ck1.Put("a", "1")
-	check(ck1, "a", "1")
-
-	os.Remove(vshosta)
-
-	// start a client Get(), but use proxy to delay it long
-	// enough that it won't reach s1 until after s1 is no
-	// longer the primary.
-	atomic.StoreInt32(&delay, 4)
-	stale_get := make(chan bool)
-	go func() {
-		local_stale := false
-		defer func() { stale_get <- local_stale }()
-		x := ck1.Get("a")
-		if x == "1" {
-			local_stale = true
-		}
-	}()
-
-	// now s1 cannot talk to viewserver, so view will change,
-	// and s1 won't immediately realize.
-
-	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
-		if vck.Primary() == s2.me {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-	if vck.Primary() != s2.me {
-		t.Fatalf("primary never changed")
-	}
-
-	// wait long enough that s2 is guaranteed to have Pinged
-	// the viewservice, and thus that s2 must know about
-	// the new view.
-	time.Sleep(2 * viewservice.PingInterval)
-
-	// change the value (on s2) so it's no longer "1".
-	ck2 := MakeClerk(vshost, "")
-	ck2.Put("a", "111")
-	check(ck2, "a", "111")
-
-	// wait for the background Get to s1 to be delivered.
-	select {
-	case x := <-stale_get:
-		if x {
-			t.Fatalf("Get to old primary succeeded and produced stale value")
-		}
-	case <-time.After(5 * time.Second):
-	}
-
-	check(ck2, "a", "111")
-
-	fmt.Printf("  ... Passed\n")
-
-	s1.kill()
-	s2.kill()
-	vs.Kill()
-}
-
-func TestPartition2(t *testing.T) {
-	runtime.GOMAXPROCS(4)
-
-	tag := "part2"
-	vshost := port(tag+"v", 1)
-	vs := viewservice.StartServer(vshost)
-	time.Sleep(time.Second)
-	vck := viewservice.MakeClerk("", vshost)
-
-	ck1 := MakeClerk(vshost, "")
-
-	vshosta := vshost + "a"
-	os.Link(vshost, vshosta)
-
-	s1 := StartServer(vshosta, port(tag, 1))
-	delay := int32(0)
-	proxy(t, port(tag, 1), &delay)
-
-	fmt.Printf("Test: Partitioned old primary does not complete Gets ...\n")
-
-	deadtime := viewservice.PingInterval * viewservice.DeadPings
-	time.Sleep(deadtime * 2)
-	if vck.Primary() != s1.me {
-		t.Fatal("primary never formed initial view")
-	}
-
-	s2 := StartServer(vshost, port(tag, 2))
-	time.Sleep(deadtime * 2)
-	v1, _ := vck.Get()
-	if v1.Primary != s1.me || v1.Backup != s2.me {
-		t.Fatal("backup did not join view")
-	}
-
-	ck1.Put("a", "1")
-	check(ck1, "a", "1")
-
-	os.Remove(vshosta)
-
-	// start a client Get(), but use proxy to delay it long
-	// enough that it won't reach s1 until after s1 is no
-	// longer the primary.
-	atomic.StoreInt32(&delay, 5)
-	stale_get := make(chan bool)
-	go func() {
-		local_stale := false
-		defer func() { stale_get <- local_stale }()
-		x := ck1.Get("a")
-		if x == "1" {
-			local_stale = true
-		}
-	}()
-
-	// now s1 cannot talk to viewserver, so view will change.
-
-	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
-		if vck.Primary() == s2.me {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-	if vck.Primary() != s2.me {
-		t.Fatalf("primary never changed")
-	}
-
-	s3 := StartServer(vshost, port(tag, 3))
-	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
-		v, _ := vck.Get()
-		if v.Backup == s3.me && v.Primary == s2.me {
-			break
-		}
-		time.Sleep(viewservice.PingInterval)
-	}
-	v2, _ := vck.Get()
-	if v2.Primary != s2.me || v2.Backup != s3.me {
-		t.Fatalf("new backup never joined")
-	}
-	time.Sleep(2 * time.Second)
-
-	ck2 := MakeClerk(vshost, "")
-	ck2.Put("a", "2")
-	check(ck2, "a", "2")
-
-	s2.kill()
-
-	// wait for delayed get to s1 to complete.
-	select {
-	case x := <-stale_get:
-		if x {
-			t.Fatalf("partitioned primary replied to a Get with a stale value")
-		}
-	case <-time.After(6 * time.Second):
-	}
-
-	check(ck2, "a", "2")
-
-	fmt.Printf("  ... Passed\n")
-
-	s1.kill()
-	s2.kill()
-	s3.kill()
-	vs.Kill()
-}
+// func TestRepeatedCrash(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
+
+// 	tag := "rc"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
+
+// 	fmt.Printf("Test: Repeated failures/restarts ...\n")
+
+// 	const nservers = 3
+// 	var sa [nservers]*PBServer
+// 	samu := sync.Mutex{}
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i] = StartServer(vshost, port(tag, i+1))
+// 	}
+
+// 	for i := 0; i < viewservice.DeadPings; i++ {
+// 		v, _ := vck.Get()
+// 		if v.Primary != "" && v.Backup != "" {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+
+// 	// wait a bit for primary to initialize backup
+// 	time.Sleep(viewservice.DeadPings * viewservice.PingInterval)
+
+// 	done := int32(0)
+
+// 	go func() {
+// 		// kill and restart servers
+// 		rr := rand.New(rand.NewSource(int64(os.Getpid())))
+// 		for atomic.LoadInt32(&done) == 0 {
+// 			i := rr.Int() % nservers
+// 			// fmt.Printf("%v killing %v\n", ts(), 5001+i)
+// 			sa[i].kill()
+
+// 			// wait long enough for new view to form, backup to be initialized
+// 			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
+
+// 			sss := StartServer(vshost, port(tag, i+1))
+// 			samu.Lock()
+// 			sa[i] = sss
+// 			samu.Unlock()
+
+// 			// wait long enough for new view to form, backup to be initialized
+// 			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
+// 		}
+// 	}()
+
+// 	const nth = 2
+// 	var cha [nth]chan bool
+// 	for xi := 0; xi < nth; xi++ {
+// 		cha[xi] = make(chan bool)
+// 		go func(i int) {
+// 			ok := false
+// 			defer func() { cha[i] <- ok }()
+// 			ck := MakeClerk(vshost, "")
+// 			data := map[string]string{}
+// 			rr := rand.New(rand.NewSource(int64(os.Getpid() + i)))
+// 			for atomic.LoadInt32(&done) == 0 {
+// 				k := strconv.Itoa((i * 1000000) + (rr.Int() % 10))
+// 				wanted, ok := data[k]
+// 				if ok {
+// 					v := ck.Get(k)
+// 					if v != wanted {
+// 						t.Fatalf("key=%v wanted=%v got=%v", k, wanted, v)
+// 					}
+// 				}
+// 				nv := strconv.Itoa(rr.Int())
+// 				ck.Put(k, nv)
+// 				data[k] = nv
+// 				// if no sleep here, then server tick() threads do not get
+// 				// enough time to Ping the viewserver.
+// 				time.Sleep(10 * time.Millisecond)
+// 			}
+// 			ok = true
+// 		}(xi)
+// 	}
+
+// 	time.Sleep(20 * time.Second)
+// 	atomic.StoreInt32(&done, 1)
+
+// 	fmt.Printf("  ... Put/Gets done ... \n")
+
+// 	for i := 0; i < nth; i++ {
+// 		ok := <-cha[i]
+// 		if ok == false {
+// 			t.Fatal("child failed")
+// 		}
+// 	}
+
+// 	ck := MakeClerk(vshost, "")
+// 	ck.Put("aaa", "bbb")
+// 	if v := ck.Get("aaa"); v != "bbb" {
+// 		t.Fatalf("final Put/Get failed")
+// 	}
+
+// 	fmt.Printf("  ... Passed\n")
+
+// 	for i := 0; i < nservers; i++ {
+// 		samu.Lock()
+// 		sa[i].kill()
+// 		samu.Unlock()
+// 	}
+// 	time.Sleep(time.Second)
+// 	vs.Kill()
+// 	time.Sleep(time.Second)
+// }
+
+// func TestRepeatedCrashUnreliable(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
+
+// 	tag := "rcu"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
+
+// 	fmt.Printf("Test: Repeated failures/restarts with concurrent updates to same key; unreliable ...\n")
+
+// 	const nservers = 3
+// 	var sa [nservers]*PBServer
+// 	samu := sync.Mutex{}
+// 	for i := 0; i < nservers; i++ {
+// 		sa[i] = StartServer(vshost, port(tag, i+1))
+// 		sa[i].setunreliable(true)
+// 	}
+
+// 	for i := 0; i < viewservice.DeadPings; i++ {
+// 		v, _ := vck.Get()
+// 		if v.Primary != "" && v.Backup != "" {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+
+// 	// wait a bit for primary to initialize backup
+// 	time.Sleep(viewservice.DeadPings * viewservice.PingInterval)
+
+// 	done := int32(0)
+
+// 	go func() {
+// 		// kill and restart servers
+// 		rr := rand.New(rand.NewSource(int64(os.Getpid())))
+// 		for atomic.LoadInt32(&done) == 0 {
+// 			i := rr.Int() % nservers
+// 			// fmt.Printf("%v killing %v\n", ts(), 5001+i)
+// 			sa[i].kill()
+
+// 			// wait long enough for new view to form, backup to be initialized
+// 			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
+
+// 			sss := StartServer(vshost, port(tag, i+1))
+// 			samu.Lock()
+// 			sa[i] = sss
+// 			samu.Unlock()
+
+// 			// wait long enough for new view to form, backup to be initialized
+// 			time.Sleep(2 * viewservice.PingInterval * viewservice.DeadPings)
+// 		}
+// 	}()
+
+// 	// concurrent client thread.
+// 	ff := func(i int, ch chan int) {
+// 		ret := -1
+// 		defer func() { ch <- ret }()
+// 		ck := MakeClerk(vshost, "")
+// 		n := 0
+// 		for atomic.LoadInt32(&done) == 0 {
+// 			v := "x " + strconv.Itoa(i) + " " + strconv.Itoa(n) + " y"
+// 			ck.Append("0", v)
+// 			// if no sleep here, then server tick() threads do not get
+// 			// enough time to Ping the viewserver.
+// 			time.Sleep(10 * time.Millisecond)
+// 			n++
+// 		}
+// 		ret = n
+// 	}
+
+// 	const nth = 2
+// 	var cha [nth]chan int
+// 	for i := 0; i < nth; i++ {
+// 		cha[i] = make(chan int)
+// 		go ff(i, cha[i])
+// 	}
+
+// 	time.Sleep(20 * time.Second)
+// 	atomic.StoreInt32(&done, 1)
+
+// 	fmt.Printf("  ... Appends done ... \n")
+
+// 	counts := []int{}
+// 	for i := 0; i < nth; i++ {
+// 		n := <-cha[i]
+// 		if n < 0 {
+// 			t.Fatal("child failed")
+// 		}
+// 		counts = append(counts, n)
+// 	}
+
+// 	fmt.Printf("Making my clerk...")
+
+// 	ck := MakeClerk(vshost, "")
+
+// 	fmt.Printf("getting 0 and checking append")
+
+// 	checkAppends(t, ck.Get("0"), counts)
+
+// 	ck.Put("aaa", "bbb")
+// 	if v := ck.Get("aaa"); v != "bbb" {
+// 		t.Fatalf("final Put/Get failed")
+// 	}
+
+// 	fmt.Printf("  ... Passed\n")
+
+// 	for i := 0; i < nservers; i++ {
+// 		samu.Lock()
+// 		sa[i].kill()
+// 		samu.Unlock()
+// 	}
+// 	time.Sleep(time.Second)
+// 	vs.Kill()
+// 	time.Sleep(time.Second)
+// }
+
+// func proxy(t *testing.T, port string, delay *int32) {
+// 	portx := port + "x"
+// 	os.Remove(portx)
+// 	if os.Rename(port, portx) != nil {
+// 		t.Fatalf("proxy rename failed")
+// 	}
+// 	l, err := net.Listen("unix", port)
+// 	if err != nil {
+// 		t.Fatalf("proxy listen failed: %v", err)
+// 	}
+// 	go func() {
+// 		defer l.Close()
+// 		defer os.Remove(portx)
+// 		defer os.Remove(port)
+// 		for {
+// 			c1, err := l.Accept()
+// 			if err != nil {
+// 				t.Fatalf("proxy accept failed: %v\n", err)
+// 			}
+// 			time.Sleep(time.Duration(atomic.LoadInt32(delay)) * time.Second)
+// 			c2, err := net.Dial("unix", portx)
+// 			if err != nil {
+// 				t.Fatalf("proxy dial failed: %v\n", err)
+// 			}
+
+// 			go func() {
+// 				for {
+// 					buf := make([]byte, 1000)
+// 					n, _ := c2.Read(buf)
+// 					if n == 0 {
+// 						break
+// 					}
+// 					n1, _ := c1.Write(buf[0:n])
+// 					if n1 != n {
+// 						break
+// 					}
+// 				}
+// 			}()
+// 			for {
+// 				buf := make([]byte, 1000)
+// 				n, err := c1.Read(buf)
+// 				if err != nil && err != io.EOF {
+// 					t.Fatalf("proxy c1.Read: %v\n", err)
+// 				}
+// 				if n == 0 {
+// 					break
+// 				}
+// 				n1, err1 := c2.Write(buf[0:n])
+// 				if err1 != nil || n1 != n {
+// 					t.Fatalf("proxy c2.Write: %v\n", err1)
+// 				}
+// 			}
+
+// 			c1.Close()
+// 			c2.Close()
+// 		}
+// 	}()
+// }
+
+// func TestPartition1(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
+
+// 	tag := "part1"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
+
+// 	ck1 := MakeClerk(vshost, "")
+
+// 	fmt.Printf("Test: Old primary does not serve Gets ...\n")
+
+// 	vshosta := vshost + "a"
+// 	os.Link(vshost, vshosta)
+
+// 	s1 := StartServer(vshosta, port(tag, 1))
+// 	delay := int32(0)
+// 	proxy(t, port(tag, 1), &delay)
+
+// 	deadtime := viewservice.PingInterval * viewservice.DeadPings
+// 	time.Sleep(deadtime * 2)
+// 	if vck.Primary() != s1.me {
+// 		t.Fatal("primary never formed initial view")
+// 	}
+
+// 	s2 := StartServer(vshost, port(tag, 2))
+// 	time.Sleep(deadtime * 2)
+// 	v1, _ := vck.Get()
+// 	if v1.Primary != s1.me || v1.Backup != s2.me {
+// 		t.Fatal("backup did not join view")
+// 	}
+
+// 	ck1.Put("a", "1")
+// 	check(ck1, "a", "1")
+
+// 	os.Remove(vshosta)
+
+// 	// start a client Get(), but use proxy to delay it long
+// 	// enough that it won't reach s1 until after s1 is no
+// 	// longer the primary.
+// 	atomic.StoreInt32(&delay, 4)
+// 	stale_get := make(chan bool)
+// 	go func() {
+// 		local_stale := false
+// 		defer func() { stale_get <- local_stale }()
+// 		x := ck1.Get("a")
+// 		if x == "1" {
+// 			local_stale = true
+// 		}
+// 	}()
+
+// 	// now s1 cannot talk to viewserver, so view will change,
+// 	// and s1 won't immediately realize.
+
+// 	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
+// 		if vck.Primary() == s2.me {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+// 	if vck.Primary() != s2.me {
+// 		t.Fatalf("primary never changed")
+// 	}
+
+// 	// wait long enough that s2 is guaranteed to have Pinged
+// 	// the viewservice, and thus that s2 must know about
+// 	// the new view.
+// 	time.Sleep(2 * viewservice.PingInterval)
+
+// 	// change the value (on s2) so it's no longer "1".
+// 	ck2 := MakeClerk(vshost, "")
+// 	ck2.Put("a", "111")
+// 	check(ck2, "a", "111")
+
+// 	// wait for the background Get to s1 to be delivered.
+// 	select {
+// 	case x := <-stale_get:
+// 		if x {
+// 			t.Fatalf("Get to old primary succeeded and produced stale value")
+// 		}
+// 	case <-time.After(5 * time.Second):
+// 	}
+
+// 	check(ck2, "a", "111")
+
+// 	fmt.Printf("  ... Passed\n")
+
+// 	s1.kill()
+// 	s2.kill()
+// 	vs.Kill()
+// }
+
+// func TestPartition2(t *testing.T) {
+// 	runtime.GOMAXPROCS(4)
+
+// 	tag := "part2"
+// 	vshost := port(tag+"v", 1)
+// 	vs := viewservice.StartServer(vshost)
+// 	time.Sleep(time.Second)
+// 	vck := viewservice.MakeClerk("", vshost)
+
+// 	ck1 := MakeClerk(vshost, "")
+
+// 	vshosta := vshost + "a"
+// 	os.Link(vshost, vshosta)
+
+// 	s1 := StartServer(vshosta, port(tag, 1))
+// 	delay := int32(0)
+// 	proxy(t, port(tag, 1), &delay)
+
+// 	fmt.Printf("Test: Partitioned old primary does not complete Gets ...\n")
+
+// 	deadtime := viewservice.PingInterval * viewservice.DeadPings
+// 	time.Sleep(deadtime * 2)
+// 	if vck.Primary() != s1.me {
+// 		t.Fatal("primary never formed initial view")
+// 	}
+
+// 	s2 := StartServer(vshost, port(tag, 2))
+// 	time.Sleep(deadtime * 2)
+// 	v1, _ := vck.Get()
+// 	if v1.Primary != s1.me || v1.Backup != s2.me {
+// 		t.Fatal("backup did not join view")
+// 	}
+
+// 	ck1.Put("a", "1")
+// 	check(ck1, "a", "1")
+
+// 	os.Remove(vshosta)
+
+// 	// start a client Get(), but use proxy to delay it long
+// 	// enough that it won't reach s1 until after s1 is no
+// 	// longer the primary.
+// 	atomic.StoreInt32(&delay, 5)
+// 	stale_get := make(chan bool)
+// 	go func() {
+// 		local_stale := false
+// 		defer func() { stale_get <- local_stale }()
+// 		x := ck1.Get("a")
+// 		if x == "1" {
+// 			local_stale = true
+// 		}
+// 	}()
+
+// 	// now s1 cannot talk to viewserver, so view will change.
+
+// 	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
+// 		if vck.Primary() == s2.me {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+// 	if vck.Primary() != s2.me {
+// 		t.Fatalf("primary never changed")
+// 	}
+
+// 	s3 := StartServer(vshost, port(tag, 3))
+// 	for iter := 0; iter < viewservice.DeadPings*3; iter++ {
+// 		v, _ := vck.Get()
+// 		if v.Backup == s3.me && v.Primary == s2.me {
+// 			break
+// 		}
+// 		time.Sleep(viewservice.PingInterval)
+// 	}
+// 	v2, _ := vck.Get()
+// 	if v2.Primary != s2.me || v2.Backup != s3.me {
+// 		t.Fatalf("new backup never joined")
+// 	}
+// 	time.Sleep(2 * time.Second)
+
+// 	ck2 := MakeClerk(vshost, "")
+// 	ck2.Put("a", "2")
+// 	check(ck2, "a", "2")
+
+// 	s2.kill()
+
+// 	// wait for delayed get to s1 to complete.
+// 	select {
+// 	case x := <-stale_get:
+// 		if x {
+// 			t.Fatalf("partitioned primary replied to a Get with a stale value")
+// 		}
+// 	case <-time.After(6 * time.Second):
+// 	}
+
+// 	check(ck2, "a", "2")
+
+// 	fmt.Printf("  ... Passed\n")
+
+// s1.kill()
+// s2.kill()
+// s3.kill()
+// vs.Kill()
+// }

--- a/src/viewservice/client.go
+++ b/src/viewservice/client.go
@@ -69,6 +69,9 @@ func (ck *Clerk) Ping(viewnum uint) (View, error) {
 }
 
 func (ck *Clerk) Get() (View, bool) {
+
+	// fmt.Println("View service client GET")
+
 	args := &GetArgs{}
 	var reply GetReply
 	ok := call(ck.server, "ViewServer.Get", args, &reply)


### PR DESCRIPTION
- I commented out all the tests after the two concurrent ones to isolate their issues
- Looks like the issue is coming from the viewservice client GET function (previous lab). It is infinitely looping if primary is set to null (for vs.View.Primary == "");  For some reasons this only happens sporadically
- I was able to reproduce this consistently on the 3 or 4th `go test'
- Fixed view service so that those tests passed again (added the start boolean to the view service)
- Tried adding mutexes in various places (get, tick, ping,...); current solution now has a more consistent hard pass / hard fail, rather than hanging.
- Made a mistake and can't auto merge - branched off your master.
